### PR TITLE
Update facts

### DIFF
--- a/sections/getting_started.tex
+++ b/sections/getting_started.tex
@@ -13,8 +13,12 @@ the systems programming language Rust» \\
 
 \begin{frame}[fragile]{Rustup.rs}
 \begin{itemize}
-    \item Makes it easy to install different Rust versions
-    \item Successor of multirust
+    \item Official installation method by now
+    \item Makes it easy to:
+      \begin{itemize}
+        \item Install different Rust versions
+        \item Install cross compilation toolchains
+      \end{itemize}
     \item Written in Rust itself
     \pause\item Installing is easy:
 \begin{minted}{sh}

--- a/sections/what_is_rust.tex
+++ b/sections/what_is_rust.tex
@@ -25,13 +25,13 @@
 %%%
 
 \begin{frame}{Quick Facts about Rust}
-	(As of April 2017)
+	(As of May 2017)
 	\begin{itemize}
 		\item Started by Mozilla employee Graydon Hoare
 		\item First announced by Mozilla in 2010
 		\item Community driven development
 		\item First stable release: 1.0 in May 2015
-		\item Latest stable release: 1.16.0
+		\item Latest stable release: 1.17.0
 		\item More than 60'000 commits on Github
 		\item Largest well-known project written in Rust: Servo\footnote{\url{https://servo.org/}}
 	\end{itemize}


### PR DESCRIPTION
Update the facts page and adapt to the fact that rustup.rs is the default installation method by now.