### PR TITLE
Remove mtheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "mtheme"]
-	path = mtheme
-	url = https://github.com/matze/mtheme

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,11 @@ LATEXMK=latexmk
 LATEXMK_ARGS=-pdf -e '$$pdflatex=q/xelatex --shell-escape %O %S/'
 
 
-slides.pdf: slides.tex theme
+slides.pdf: slides.tex
 	${LATEXMK} ${LATEXMK_ARGS} slides.tex
-
-theme: mtheme
-	cd mtheme && make sty
-	cp mtheme/*.sty .
 
 clean:
 	latexmk -c
 	rm -rf _minted-slides/ *.sty *.snm *.vrb *.nav
 
-PHONY: theme clean
+PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LATEXMK=latexmk
 LATEXMK_ARGS=-pdf -e '$$pdflatex=q/xelatex --shell-escape %O %S/'
 
 
-slides.pdf: slides.tex
+slides.pdf: slides.tex sections/*.tex
 	${LATEXMK} ${LATEXMK_ARGS} slides.tex
 
 clean:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Requirements:
 - latexmk
 - Fira fonts
 - pygmentize
+- metropolis theme (part of TeXlive 2016+)
 
-To install the dependencies under Ubuntu 16.04:
+To install the dependencies under Ubuntu 18.04:
 ```
-sudo apt install texlive-xetex texlive-fonts-extra python-pygments
+sudo apt install texlive-xetex texlive-fonts-extra texlive-latex-extra python-pygments
 ```
 
 ## Building
@@ -23,7 +24,8 @@ First, install Fira Sans and Fira Mono fonts on your system:
 
 Then build the slides:
 
-    git clone --recursive https://github.com/coredump-ch/intro-to-rust
+    git clone https://github.com/coredump-ch/intro-to-rust
+    cd intro-to-rust
     make
 
 ## [License](LICENSE)


### PR DESCRIPTION
It has been renamed to "metropolis" and is part of TeXlive 2016. Thus,
the submodule is not required anymore (and causes the compilation to
hang).

See https://github.com/matze/mtheme/issues/292