### PR TITLE
Fix .editorconfig for .tex files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[*.tex]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
The configuration did not match the actually used indentation format.